### PR TITLE
Use baseName

### DIFF
--- a/Infrastructure.fsx
+++ b/Infrastructure.fsx
@@ -7,9 +7,12 @@ open System.Diagnostics
 
 Environment.CurrentDirectory <- __SOURCE_DIRECTORY__ 
 
-/// UPDATE THESE TWO NAMES TO SOMETHING UNIQUE TO YOU
-let storageAccountName = "demoidentitystorage"
-let webAppName = "demoidentityweb"
+/// UPDATE baseName TO SOMETHING UNIQUE TO YOU
+
+let baseName = "farmeriddemojong"
+let storageAccountName = baseName + "storage"
+let webAppName = baseName + "app"
+let rg = baseName + "rg"
 
 // Create and configure a Farmer template of a web app and storage account
 let myWeb = webApp {
@@ -32,7 +35,7 @@ let template = arm {
 }
 
 // Deploy the template to the "identity-demo" resource group
-template |> Deploy.execute "identity-demo" []
+template |> Deploy.execute rg []
 
 // Prime the storage account with some seed data
 let deployFile (fileName:string) =

--- a/readme.md
+++ b/readme.md
@@ -20,11 +20,11 @@ dotnet publish -c Release -o publish
 ```
 
 #### 2. Configure the Farmer template
-Open the `Infrastructure.fsx` file and update the `storageAccountName` and `webAppName` values to strings unique to you.
+Open the `Infrastructure.fsx` file and update the `baseName` value to something that is unique to you.  The resource group, storage account, and web app names will be generated from this value.
 
 #### 3. Execute the script
 * Highlight the contents of the script
-* Execute the code (`ALT` + `ENTER` in VS or Code)
+* Execute the code (`ALT` + `ENTER` in VS or VS Code)
 
 The script:
 


### PR DESCRIPTION
1. Do I have to call dotnet publish or can farmer do that?
2. Getting string iterpolation error in Program.fs
Feature 'string interpolation' is not available in F# 4.7. Please use language version 'preview' or greater.F# Compiler(3350)

3. ALT+ENTER - Did not execute the script for me.
4. Got this error when running:
Uploading Infrastructure.fsx...
System.ComponentModel.Win32Exception (2): No such file or directory
   at System.Diagnostics.Process.ForkAndExecProcess(String filename, String[] argv, String[] envp, String cwd, Boolean redirectStdin, Boolean redirectStdout, Boolean redirectStderr, Boolean setCredentials, UInt32 userId, UInt32 groupId, UInt32[] groups, Int32& stdinFd, Int32& stdoutFd, Int32& stderrFd, Boolean usesTerminal, Boolean throwOnNoExec)
   at System.Diagnostics.Process.StartCore(ProcessStartInfo startInfo)
   at System.Diagnostics.Process.Start()
   at System.Diagnostics.Process.Start(ProcessStartInfo startInfo)
   at <StartupCode$FSI_0002>.$FSI_0002.main@()
Stopped due to error