### PR TITLE
Remove dashes from web app setting name

### DIFF
--- a/infrastructure/Program.fs
+++ b/infrastructure/Program.fs
@@ -15,14 +15,15 @@ let rg = $"{baseName}-rg"
 let myWeb = webApp {
     name webAppName
     system_identity
-    setting "storage-account-name" storageAccountName
+    operating_system OS.Windows
+    setting "StorageAccountName" storageAccountName
     zip_deploy "../publish"
     run_from_package
 }
 
 let storage = storageAccount {
     name storageAccountName
-    add_blob_container "data"
+    add_private_container "data"
     grant_access myWeb.SystemIdentity Roles.StorageBlobDataReader
 }
 

--- a/webapp/Program.fs
+++ b/webapp/Program.fs
@@ -6,7 +6,7 @@ open Saturn
 open System
 
 // Get the storage account name from an environment variable - will be set by Farmer during ARM deploy.
-let storageAccountName = Environment.GetEnvironmentVariable "storage-account-name"
+let storageAccountName = Environment.GetEnvironmentVariable "StorageAccountName"
 
 // Connect to Azure Storage using the default azure credentials (which includes the system identity).
 let blobClient =


### PR DESCRIPTION
* Switch to Windows as a default (only because of the limit of one free Linux app service per region)
* Remove the dashes from the setting name anyway, in case anyone wants to deploy to Linux
* Changed `add_blob_container` to `add_private_container` to avoid another ARM deploy error. Presumably it was suggesting it doesn't make sense to grant identity access to a public container.

Closes #2